### PR TITLE
Async requests on writes

### DIFF
--- a/nodestream/databases/neptunedb/ingest_query_builder.py
+++ b/nodestream/databases/neptunedb/ingest_query_builder.py
@@ -1,4 +1,6 @@
 import re
+import math
+import numbers
 from pandas import Timestamp
 from datetime import datetime, timedelta
 from functools import cache, wraps
@@ -118,7 +120,9 @@ def _to_string_values(props: dict):
         if isinstance(v, Timestamp):
             props[k] = str(v)
         elif not v:
-            props[k] = ''
+            props[k] = 'None'
+        elif isinstance(v, numbers.Number) and math.isnan(v):
+            props[k] = "NaN"
 
     return props
 

--- a/nodestream/databases/neptunedb/neptune_database_connector.py
+++ b/nodestream/databases/neptunedb/neptune_database_connector.py
@@ -19,6 +19,7 @@ class NeptuneDBDatabaseConnector(DatabaseConnector, alias="neptunedb"):
         return cls(
             host=host,
             region=region,
+            async_partitions=kwargs.get("async_partitions"),
             ingest_query_builder=NeptuneDBIngestQueryBuilder()
         )
 
@@ -26,11 +27,13 @@ class NeptuneDBDatabaseConnector(DatabaseConnector, alias="neptunedb"):
         self,
         region,
         host,
+        async_partitions,
         ingest_query_builder: NeptuneDBIngestQueryBuilder
     ) -> None:
         self.host = host
         self.region = region
         self.ingest_query_builder = ingest_query_builder
+        self.async_partitions = async_partitions
 
     def make_query_executor(self) -> QueryExecutor:
         from .query_executor import NeptuneQueryExecutor
@@ -38,7 +41,8 @@ class NeptuneDBDatabaseConnector(DatabaseConnector, alias="neptunedb"):
         return NeptuneQueryExecutor(
             host=self.host,
             region=self.region,
-            ingest_query_builder=self.ingest_query_builder
+            ingest_query_builder=self.ingest_query_builder,
+            async_partitions=self.async_partitions
         )
 
     def make_type_retriever(self) -> TypeRetriever:


### PR DESCRIPTION
Added a `async_partitions` param to config yaml
- `async_partitions` specify how much we will split the parameters into async requests
  - Ex: if `async_partitions=50` then 1000 nodes will be split into 50 async requests each inserting 100 modes.
- This however does not seems to improve performance as much as batched query.
  - Could be that there's an overhead on each requests to Neptune.
  - Could be that the insert size is too small.
  - Need more investigation. 